### PR TITLE
database.ymlの環境変数の修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,4 @@ production:
   <<: *default
   database: migacode_production
   username: migacode
-  password: <%= ENV['MIGACODE_DATABASE_PASSWORD'] %>
+  password: <%= ENV.fetch("MIGACODE_DATABASE_PASSWORD") %>


### PR DESCRIPTION
## 概要
database.ymlの環境変数の修正

```<%= ENV['MIGACODE_DATABASE_PASSWORD']  %>```
では環境変数の設定追加がエラーになるため、
```pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>```
のようにENV.fetch()でMIGACODE_DATABASE_PASSWORDを設定します

## レビュアー
@sunecosuri 