### PR TITLE
herokuのrubyバージョンを2.4.1に設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.4.1"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,5 +187,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
## 概要
- herokuのrubyを2.4.1に設定
  - rubyのバージョンをを設定しないとheroku側のデフォルトで設定してあるrubyが動くため
参考本:https://devcenter.heroku.com/changelog-items/1116

## TODO
- [x]  herokuのrubyを2.4.1に設定
## レビュアー
@sunecosuri @dp42 